### PR TITLE
[refactor] mlx_draw_pixel 함수 내의 조건문을 is_inside_window로 변경

### DIFF
--- a/engine_macos/gl_lib/draw/gl_draw_pixel.c
+++ b/engine_macos/gl_lib/draw/gl_draw_pixel.c
@@ -6,21 +6,31 @@
 /*   By: minkyeki <minkyeki@student.42seoul.kr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/09/01 16:41:10 by minkyeki          #+#    #+#             */
-/*   Updated: 2022/09/04 21:43:39 by minkyeki         ###   ########.fr       */
+/*   Updated: 2022/09/06 01:05:14 by minkyeki         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "gl_draw.h"
 
-void	gl_draw_pixel(t_image *image, int _x, int _y, int argb)
+bool	is_inside_image(t_image *image, int _x, int _y)
 {
-	char	*pixel;
-
 	if (_x < image->width && _x > 0 && \
 			_y < image->height && _y > 0)
 	{
+		return (true);
+	}
+	else 
+		return (false);
+}
+
+void	gl_draw_pixel(t_image *_image, int _x, int _y, int _argb)
+{
+	char	*pixel;
+
+	if (is_inside_image(_image, _x, _y))
+	{
 		pixel = image->addr + (_y * image->line_length \
 				+ _x * (image->bits_per_pixel / 8));
-		*(unsigned int *)pixel = argb;
+		*(unsigned int *)pixel = _argb;
 	}
 }

--- a/engine_macos/include/gl_draw.h
+++ b/engine_macos/include/gl_draw.h
@@ -6,19 +6,15 @@
 /*   By: parksungjun <parksungjun@student.42seou    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/09/01 16:57:40 by minkyeki          #+#    #+#             */
-/*   Updated: 2022/09/05 23:08:01 by parksungjun      ###   ########seoul.kr  */
+/*   Updated: 2022/09/06 01:07:37 by minkyeki         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef GL_DRAW_H
 # define GL_DRAW_H
 
-
-# if defined (__linux__)
-#  include "../../../../mlx_linux/mlx.h"
-# elif defined (__APPLE__)
-#  include "mlx.h"
-# endif
+/* NOTE: deleted #ifndef macro, because of -I include option */
+# include "mlx.h"
 # include "gl_device.h"
 
 /* Default Coordinate system: from (Screen Width ~ Screen Height). */


### PR DESCRIPTION
(1) Discussion에서 언급된 부분 수정했습니다!
---------------------------------------------------
+) 프로젝트의 최상단 경로에서 engine_linux와 engine_macos로 파일구조를 분리하신 이유가 궁금합니다.
이유 : Linux와 MacOS를 구분해야 하는 파일은 키맵 헤더(ex. key_map_linux.h, key_map_macos.h)와 mlx_mouse_get_pos() 함수가 사용된 부분이며, 그 외에는 둘다 동일한 코드를 사용함. --> 최상단에서부터 linux/macos로 나누면 gl_core/gl_lib에서 중복되는 코드가 발생함